### PR TITLE
ci: fix broken postgres backup, make prune deploy-safe, harden deploy rollback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-concurrency:
-  group: deploy-production
-  cancel-in-progress: false
-
 permissions:
   contents: read
 
@@ -44,6 +40,13 @@ jobs:
     needs: ci
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.ref == 'refs/heads/main'
+
+    # Shared with the scheduled Docker prune so the two can never touch the
+    # EC2 box at the same time. Scoped to this job so PR CI is not queued
+    # behind a running production deploy.
+    concurrency:
+      group: ec2-production
+      cancel-in-progress: false
 
     steps:
       - name: Deploy to EC2
@@ -86,6 +89,25 @@ jobs:
               check_disk_space
             }
 
+            # Build sequentially: building all three at once is what exhausted
+            # the disk previously. Used by both the forward and rollback paths.
+            build_images() {
+              docker compose build be && docker compose build ws && docker compose build web
+            }
+
+            rollback_to() {
+              TARGET="$1"
+              echo "Rolling back to $TARGET"
+              cleanup_docker
+              git reset --hard "$TARGET"
+              if ! build_images; then
+                echo "Rollback build failed; leaving current containers running"
+                exit 1
+              fi
+              docker compose --env-file .env up -d --remove-orphans
+              exit 1
+            }
+
             # Ensure we're on main branch (previous rollback may have left detached HEAD)
             git checkout main
 
@@ -93,23 +115,21 @@ jobs:
             PREV_COMMIT=$(git rev-parse HEAD)
             echo "Previous commit: $PREV_COMMIT"
 
-            # Pull new code
-            git stash
-            git pull origin main || { echo "git pull failed, rolling back"; git reset --hard "$PREV_COMMIT"; exit 1; }
-
             export COMPOSE_HTTP_TIMEOUT=300
             export DOCKER_CLIENT_TIMEOUT=300
 
+            # Reclaim disk and bail before touching the working tree, so a
+            # low-disk abort leaves the box on the currently deployed commit.
             prepare_for_build
 
-            # Build images sequentially to avoid peak disk usage
-            if ! (docker compose build be && docker compose build ws && docker compose build web); then
-              echo "Build failed, rolling back to $PREV_COMMIT"
-              cleanup_docker
-              git reset --hard "$PREV_COMMIT"
-              docker compose --env-file .env down --rmi local 2>/dev/null || true
-              docker compose --env-file .env up -d --remove-orphans --build
-              exit 1
+            # Discard local drift, then pull new code. Deliberately not `git
+            # stash`: stashes were never popped and accumulated on the box.
+            git reset --hard HEAD
+            git pull origin main || { echo "git pull failed, rolling back"; git reset --hard "$PREV_COMMIT"; exit 1; }
+
+            if ! build_images; then
+              echo "Build failed"
+              rollback_to "$PREV_COMMIT"
             fi
 
             # Deploy
@@ -129,12 +149,8 @@ jobs:
             done
 
             if [ "$HEALTHY" = false ]; then
-              echo "Health check failed, rolling back to $PREV_COMMIT"
-              cleanup_docker
-              git reset --hard "$PREV_COMMIT"
-              docker compose --env-file .env down --rmi local 2>/dev/null || true
-              docker compose --env-file .env up -d --remove-orphans --build
-              exit 1
+              echo "Health check failed"
+              rollback_to "$PREV_COMMIT"
             fi
 
             cleanup_after_build

--- a/.github/workflows/docker-prune.yml
+++ b/.github/workflows/docker-prune.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# Shared with the deploy job so a prune can never land mid-deploy, when the
+# stack's images and named volumes are briefly unreferenced.
+concurrency:
+  group: ec2-production
+  cancel-in-progress: false
+
 jobs:
   prune:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -25,6 +31,15 @@ jobs:
             set -e
             echo "Docker usage before prune:"
             docker system df || true
-            docker system prune -af --volumes
+
+            # Deliberately not `-af --volumes`:
+            #   -a         evicts every image not backed by a running container,
+            #              so the next deploy rebuilds cold and hits the same
+            #              disk pressure this prune exists to prevent.
+            #   --volumes  can reap the stack's named volumes (postgres-data,
+            #              redis-data, kafka-data) while they are unattached.
+            docker system prune -f --filter "until=72h"
+            docker builder prune -f --keep-storage=10g
+
             echo "Docker usage after prune:"
             docker system df || true

--- a/.github/workflows/postgres-backup.yml
+++ b/.github/workflows/postgres-backup.yml
@@ -5,13 +5,15 @@ on:
     - cron: '0 2 * * *' # daily at 02:00 UTC
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   backup:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      # No checkout: the dump runs entirely from a pinned postgres image and
+      # writes to RUNNER_TEMP, so repo contents are not needed.
       - name: Run Postgres backup
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
@@ -24,50 +26,52 @@ jobs:
         run: |
           set -euo pipefail
 
-          BACKUP_DIR="$GITHUB_WORKSPACE/scripts/backups"
+          # A dump that is not uploaded is not a backup: the runner workspace is
+          # ephemeral. Fail loudly instead of reporting a green run.
+          if [ -z "${DATABASE_URL:-}" ]; then
+            echo "DATABASE_URL is not set; nothing to back up." >&2
+            exit 1
+          fi
+          if [ -z "${AWS_S3_BUCKET:-}" ]; then
+            echo "AWS_S3_BUCKET is not set; the dump would be discarded with the runner." >&2
+            exit 1
+          fi
+
+          BACKUP_DIR="$RUNNER_TEMP/backups"
           mkdir -p "$BACKUP_DIR"
 
           TIMESTAMP=$(date -u +"%Y%m%dT%H%M%SZ")
           FILENAME="db-${TIMESTAMP}.dump"
           OUT_PATH="$BACKUP_DIR/$FILENAME"
 
-          echo "Creating PostgreSQL dump: $OUT_PATH"
+          # Always dump from a pinned client image. The runner's system pg_dump
+          # is 16.x and aborts with "server version mismatch" against our 17.x
+          # server, which is why every scheduled run has been failing.
+          DOCKER_IMAGE="${PG_DOCKER_IMAGE:-postgres:17}"
+          echo "Creating PostgreSQL dump with $DOCKER_IMAGE: $OUT_PATH"
 
-          if command -v pg_dump >/dev/null 2>&1; then
-            if [ -n "${DATABASE_URL:-}" ]; then
-              pg_dump --format=custom --file="$OUT_PATH" --dbname="$DATABASE_URL"
-            else
-              pg_dump --format=custom --file="$OUT_PATH"
-            fi
-          else
-            echo "pg_dump not found locally. Trying Docker fallback..."
-            if ! command -v docker >/dev/null 2>&1; then
-              echo "pg_dump not found and Docker is not available." >&2
-              exit 127
-            fi
+          docker run --rm \
+            -v "$BACKUP_DIR":/backups \
+            -e DATABASE_URL \
+            -e FILENAME="$FILENAME" \
+            "$DOCKER_IMAGE" \
+            bash -c 'pg_dump --format=custom --file="/backups/$FILENAME" --dbname="$DATABASE_URL"'
 
-            DOCKER_IMAGE="${PG_DOCKER_IMAGE:-postgres:17}"
-            echo "Using Docker image: $DOCKER_IMAGE"
+          if [ ! -s "$OUT_PATH" ]; then
+            echo "Dump is missing or empty: $OUT_PATH" >&2
+            exit 1
+          fi
+          echo "Backup created: $OUT_PATH ($(du -h "$OUT_PATH" | cut -f1))"
 
-            docker run --rm \
-              -v "$BACKUP_DIR":/backups \
-              -e DATABASE_URL="${DATABASE_URL:-}" \
-              -e PGHOST="${PGHOST:-}" -e PGPORT="${PGPORT:-}" -e PGUSER="${PGUSER:-}" -e PGPASSWORD="${PGPASSWORD:-}" -e PGDATABASE="${PGDATABASE:-}" \
-              "$DOCKER_IMAGE" bash -lc "if [ -n \"\$DATABASE_URL\" ]; then pg_dump --format=custom --file=/backups/${FILENAME} --dbname=\"\$DATABASE_URL\"; else pg_dump --format=custom --file=/backups/${FILENAME}; fi"
+          if ! command -v aws >/dev/null 2>&1; then
+            echo "aws CLI not found on runner; cannot upload backup." >&2
+            exit 1
+          fi
+          if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "AWS credentials not set; cannot upload backup." >&2
+            exit 1
           fi
 
-          echo "Backup created: $OUT_PATH"
-
-          if [ -n "${AWS_S3_BUCKET:-}" ]; then
-            if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
-              echo "AWS credentials not set; skipping S3 upload" >&2
-            elif ! command -v aws >/dev/null 2>&1; then
-              echo "aws CLI not found; skipping S3 upload" >&2
-            else
-              echo "Uploading $OUT_PATH to s3://$AWS_S3_BUCKET/"
-              aws s3 cp "$OUT_PATH" "s3://$AWS_S3_BUCKET/$(basename "$OUT_PATH")"
-              echo "Upload complete"
-            fi
-          fi
-
-          echo "Done."
+          echo "Uploading $OUT_PATH to s3://$AWS_S3_BUCKET/$FILENAME"
+          aws s3 cp "$OUT_PATH" "s3://$AWS_S3_BUCKET/$FILENAME"
+          echo "Upload complete."


### PR DESCRIPTION
Three fixes to the workflows, one of which is actively broken in production.

**The scheduled Postgres backup has never succeeded.** Every run, including today's 05:57 UTC one, dies the same way:

```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 17.10 (4f20678); pg_dump version: 16.11 (Ubuntu 16.11-1.pgdg24.04+1)
```

The runner image ships pg_dump 16, so the `command -v pg_dump` branch always won and the pinned `postgres:17` fallback was dead code. Now the dump always runs from the pinned image, with the URL passed through the environment rather than argv:

```yaml
docker run --rm \
  -v "$BACKUP_DIR":/backups \
  -e DATABASE_URL \
  -e FILENAME="$FILENAME" \
  "$DOCKER_IMAGE" \
  bash -c 'pg_dump --format=custom --file="/backups/$FILENAME" --dbname="$DATABASE_URL"'
```

The old script also `echo`d "skipping S3 upload" and exited 0 when creds or the `aws` CLI were missing. Since the dump only ever lived in the ephemeral runner workspace, that was a green run with no backup anywhere. Missing `DATABASE_URL`, missing bucket, missing creds, and an empty dump file are all hard failures now. The checkout step is gone because the job no longer reads repo contents.

**The nightly Docker prune could land mid-deploy.** `docker-prune.yml` and `deploy.yml` shared no concurrency group, so `docker system prune -af --volumes` at 03:00 UTC could fire while a deploy had images and named volumes briefly unreferenced. Both now sit in one `ec2-production` group, and the prune is narrowed:

```yaml
docker system prune -f --filter "until=72h"
docker builder prune -f --keep-storage=10g
```

Dropping `-a` matters beyond the race: it was evicting every image not backed by a running container plus the build cache each night, quietly undoing the `--keep-storage=2g` the deploy sets and forcing the first deploy of each day to rebuild cold, which is the same disk pressure the prune exists to relieve.

**Deploy rollback rebuilt in parallel, the pattern that caused the outage.** The forward path builds `be`, `ws`, `web` sequentially to cap peak disk, but both rollback branches called `docker compose up -d --build`, so a rollback triggered by disk exhaustion could itself fail on disk exhaustion. Both paths now share one helper, and rollback no longer does `down --rmi local` first, so the site is not fully torn down for the length of a rebuild:

```bash
build_images() {
  docker compose build be && docker compose build ws && docker compose build web
}

rollback_to() {
  TARGET="$1"
  cleanup_docker
  git reset --hard "$TARGET"
  if ! build_images; then
    echo "Rollback build failed; leaving current containers running"
    exit 1
  fi
  docker compose --env-file .env up -d --remove-orphans
  exit 1
}
```

Also in that job: the disk precheck moved ahead of `git pull`, so a low-disk abort leaves the box on the deployed commit instead of new code with old containers; `git stash` became `git reset --hard HEAD`, since the stashes were never popped and had been piling up on the host; and `concurrency` moved from the workflow level onto the `deploy` job, so PR CI stops queueing behind production deploys (a PR run sat pending for eight minutes yesterday for exactly this reason).

Validated by parsing all three workflows and `bash -n` on each embedded script. The prune and backup paths can only really be exercised on their schedules, so `workflow_dispatch` on the backup is the fastest way to confirm the pg_dump fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nerdev-co/codesmith/modheshwari/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->