### PR TITLE
fix(be): repair type errors blocking build and deploy

### DIFF
--- a/apps/be/kafka/workers/fanoutWorker.ts
+++ b/apps/be/kafka/workers/fanoutWorker.ts
@@ -63,7 +63,7 @@ export async function processFanoutMessage(opts: {
         const TTL = Number(
           process.env.NOTIFICATION_CACHE_TTL_SECONDS || 60 * 60 * 24 * 7,
         );
-        const pipeline = redis.pipeline();
+        const pipeline = redis.multi();
         for (const item of data) {
           const key = `notifications:${item.userId}`;
           pipeline.rPush(

--- a/apps/be/routes/familyTree/handlers.ts
+++ b/apps/be/routes/familyTree/handlers.ts
@@ -7,7 +7,7 @@ import prisma from "@modheshwari/db";
 import { success, failure } from "@modheshwari/utils/response";
 
 import { requireAuth } from "../authMiddleware";
-import getRedisClient from "../lib/redisClient";
+import getRedisClient from "../../lib/redisClient";
 import type { TreeView, TreeFormat } from "./types";
 import { buildAncestorTree, buildDescendantTree, buildFullTree } from "./builders";
 import { buildGraphData } from "./graph";

--- a/apps/be/routes/me.ts
+++ b/apps/be/routes/me.ts
@@ -17,6 +17,52 @@ function profileCacheKey(userId: string): string {
   return `user:profile:${userId}`;
 }
 
+function fetchUserWithFamilies(userId: string) {
+  return prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      status: true,
+
+      profile: {
+        select: {
+          phone: true,
+          address: true,
+          profession: true,
+          gotra: true,
+          location: true,
+          locationLat: true,
+          locationLng: true,
+          bloodGroup: true,
+          allergies: true,
+          medicalNotes: true,
+        },
+      },
+
+      families: {
+        select: {
+          id: true,
+          familyId: true,
+          joinedAt: true,
+          family: {
+            select: {
+              id: true,
+              name: true,
+              uniqueId: true,
+            },
+          },
+          role: true,
+        },
+      },
+    },
+  });
+}
+
+type MeUser = NonNullable<Awaited<ReturnType<typeof fetchUserWithFamilies>>>;
+
 /**
  * GET /api/me
  * Returns the authenticated user's details and the families they belong to.
@@ -32,52 +78,14 @@ export async function handleGetMe(req: Request): Promise<Response> {
     const cacheKey = profileCacheKey(userId);
     const cached = await redis.get(cacheKey);
 
-    let user;
+    let user: MeUser | null;
 
     if (cached) {
-      user = JSON.parse(cached);
+      // Dates come back as ISO strings after the JSON round-trip; the response
+      // is re-serialized below, so the wire shape is identical either way.
+      user = JSON.parse(cached) as MeUser;
     } else {
-      user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          role: true,
-          status: true,
-
-          profile: {
-            select: {
-              phone: true,
-              address: true,
-              profession: true,
-              gotra: true,
-              location: true,
-              locationLat: true,
-              locationLng: true,
-              bloodGroup: true,
-              allergies: true,
-              medicalNotes: true,
-            },
-          },
-
-          families: {
-            select: {
-              id: true,
-              familyId: true,
-              joinedAt: true,
-              family: {
-                select: {
-                  id: true,
-                  name: true,
-                  uniqueId: true,
-                },
-              },
-              role: true,
-            },
-          },
-        },
-      });
+      user = await fetchUserWithFamilies(userId);
 
       if (user) {
         await redis.set(cacheKey, JSON.stringify(user), {

--- a/apps/be/routes/notifications.ts
+++ b/apps/be/routes/notifications.ts
@@ -192,7 +192,7 @@ export async function handleCreateNotification(req: Request) {
                 const now = new Date().toISOString();
                 const previewId = result?.eventId || randomUUID();
                 const PREVIEW_TTL = Number(process.env.NOTIFICATION_PREVIEW_TTL_SECONDS || 60);
-                const pipeline = redis.pipeline();
+                const pipeline = redis.multi();
                 for (const u of users) {
                     const payload = JSON.stringify({ notification: { previewId, message, subject: subject ?? null, createdAt: now } });
                     pipeline.publish(`inapp:${u.id}`, payload);

--- a/apps/be/routes/resourceReq.ts
+++ b/apps/be/routes/resourceReq.ts
@@ -78,6 +78,8 @@ export async function handleCreateResourceRequest(
 
         /* -------- Identify approvers -------- */
 
+        const approvers: Array<{ id: string; role: string; name: string }> = [];
+
         const [communityHead, communitySub, profile] = await Promise.all([
             prisma.user.findFirst({
                 where: { role: "COMMUNITY_HEAD", status: true },


### PR DESCRIPTION
`main` does not compile. `be#build` has been failing since the recent perf series, and because `deploy` is gated on `ci`, it is being skipped: production is still running the PR #7 merge commit, not the perf work. Eight errors, four distinct causes.

**`resourceReq.ts` lost its `approvers` declaration.** Commit 3b9ebb4 parallelized the approver lookups with `Promise.all` and deleted `const approvers` along with the sequential queries, but left all four `approvers.push(...)` call sites and the transaction loop that reads it (TS2304 x4). Restored:

```ts
const approvers: Array<{ id: string; role: string; name: string }> = [];
```

**`me.ts` went implicitly `any` through the cache branch.** `let user;` assigned from either `JSON.parse(cached)` or the Prisma query infers `any`, so `user.families.map((fm) => ...)` tripped `noImplicitAny` (TS7006). Rather than annotate the callback, the query is now a function and the type is derived from it, so both branches agree on one shape:

```ts
type MeUser = NonNullable<Awaited<ReturnType<typeof fetchUserWithFamilies>>>;

let user: MeUser | null;
if (cached) {
  user = JSON.parse(cached) as MeUser;
} else {
  user = await fetchUserWithFamilies(userId);
  // ...
}
```

Worth flagging: `joinedAt` is a `Date` from Prisma but an ISO string after the cache round-trip, so that cast is slightly optimistic. It is harmless here because the value is only re-serialized into the response, but anything that later does date arithmetic on a cached `/me` will need a revive step.

**`redis.pipeline()` is ioredis, not node-redis.** `lib/redisClient.ts` builds a `redis@5.10.0` client, which queues with `multi()`; there is no `pipeline()` on `RedisClientType` (TS2339 in `fanoutWorker.ts` and `notifications.ts`). Swapped to `redis.multi()`, which has the same queue-then-`exec()` semantics, so the batching intent of fc85b45 is preserved.

**`familyTree/handlers.ts` imported one directory too shallow.** `../lib/redisClient` from `routes/familyTree/` resolves to `routes/lib/redisClient`; corrected to `../../lib/redisClient`.

Verified by reproducing all eight errors against unpatched `main` with `bunx tsc --noEmit` in `apps/be`, then confirming the patched tree is clean and `bunx turbo run lint check-types build` passes all 7 tasks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nerdev-co/codesmith/modheshwari/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->